### PR TITLE
feat: Add Prometheus metrics support to router service

### DIFF
--- a/src/sgorch/main.py
+++ b/src/sgorch/main.py
@@ -238,6 +238,16 @@ def router(
     request_timeout: float = typer.Option(30.0, "--request-timeout", help="Upstream request timeout in seconds"),
     max_retries: int = typer.Option(3, "--max-retries", help="Maximum proxy attempts before failing"),
     failure_cooldown: float = typer.Option(5.0, "--failure-cooldown", help="Cooldown seconds before retrying an unhealthy worker"),
+    prometheus_port: Optional[int] = typer.Option(
+        None,
+        "--prometheus-port",
+        help="Expose Prometheus metrics on the given port"
+    ),
+    router_name: Optional[str] = typer.Option(
+        None,
+        "--router-name",
+        help="Optional router name label to attach to Prometheus metrics"
+    ),
     log_level: str = typer.Option("INFO", "--log-level", "-l", help="Log level (DEBUG, INFO, WARNING, ERROR)"),
 ):
     """Run the standalone proxy router service."""
@@ -249,6 +259,10 @@ def router(
         logger.error("max_retries must be at least 1")
         raise typer.Exit(1)
 
+    if prometheus_port is not None and prometheus_port <= 0:
+        logger.error("prometheus_port must be a positive integer")
+        raise typer.Exit(1)
+
     runtime_config = RouterRuntimeConfig(
         bind_host=host,
         bind_port=port,
@@ -258,6 +272,9 @@ def router(
         request_timeout_s=request_timeout,
         max_retries=max_retries,
         failure_cooldown_s=failure_cooldown,
+        prometheus_port=prometheus_port,
+        prometheus_host=host if prometheus_port is not None else None,
+        router_name=router_name,
     )
 
     runtime = RouterRuntime(runtime_config)

--- a/src/sgorch/router/metrics.py
+++ b/src/sgorch/router/metrics.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import threading
+from typing import Dict, Optional
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, start_http_server
+
+from ..logging_setup import get_logger
+
+
+logger = get_logger(__name__)
+
+
+class RouterMetrics:
+    """Prometheus metrics instrumentation for the standalone router."""
+
+    def __init__(self, *, router_name: Optional[str] = None, registry: Optional[CollectorRegistry] = None) -> None:
+        self.registry = registry or CollectorRegistry()
+        self.router_name = router_name or "default"
+
+        # Worker lifecycle
+        self._workers = Gauge(
+            "sgorch_router_workers",
+            "Number of workers tracked by the router, by status",
+            ["router", "status"],
+            registry=self.registry,
+        )
+        self._worker_state_changes = Counter(
+            "sgorch_router_worker_state_changes_total",
+            "Worker status transition events",
+            ["router", "worker", "status"],
+            registry=self.registry,
+        )
+        self._worker_registrations = Counter(
+            "sgorch_router_workers_registered_total",
+            "Worker registration activity",
+            ["router", "action"],
+            registry=self.registry,
+        )
+
+        # Proxy traffic
+        self._proxy_requests = Counter(
+            "sgorch_router_proxy_requests_total",
+            "Total proxy attempts to upstream workers",
+            ["router", "method", "outcome", "status_code"],
+            registry=self.registry,
+        )
+        self._proxy_latency = Histogram(
+            "sgorch_router_proxy_request_latency_seconds",
+            "Latency of proxy attempts to upstream workers",
+            ["router", "method", "outcome"],
+            registry=self.registry,
+        )
+        self._proxy_inflight = Gauge(
+            "sgorch_router_proxy_inflight_requests",
+            "Number of inflight proxy attempts",
+            ["router", "method"],
+            registry=self.registry,
+        )
+        self._proxy_retries = Counter(
+            "sgorch_router_retries_total",
+            "Retries performed while proxying requests",
+            ["router", "reason"],
+            registry=self.registry,
+        )
+        self._proxy_failures = Counter(
+            "sgorch_router_failed_attempts_total",
+            "Terminal proxy failures after retries were exhausted",
+            ["router", "reason"],
+            registry=self.registry,
+        )
+
+        # Health probes
+        self._health_probes = Counter(
+            "sgorch_router_health_probes_total",
+            "Worker health probe results",
+            ["router", "worker", "result"],
+            registry=self.registry,
+        )
+        self._health_latency = Histogram(
+            "sgorch_router_health_probe_duration_seconds",
+            "Latency of worker health probes",
+            ["router", "worker"],
+            registry=self.registry,
+        )
+        self._health_last_success = Gauge(
+            "sgorch_router_health_last_success_timestamp",
+            "Unix timestamp of the last successful health probe",
+            ["router", "worker"],
+            registry=self.registry,
+        )
+
+        self._http_server_port: Optional[int] = None
+        self._http_server_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Worker metrics helpers
+    def update_worker_counts(self, counts: Dict[str, int]) -> None:
+        for status in ("healthy", "unhealthy", "unknown"):
+            value = counts.get(status, 0)
+            self._workers.labels(router=self.router_name, status=status).set(value)
+
+    def record_worker_state(self, worker: str, status: str) -> None:
+        self._worker_state_changes.labels(router=self.router_name, worker=worker, status=status).inc()
+
+    def record_worker_registration(self, action: str) -> None:
+        self._worker_registrations.labels(router=self.router_name, action=action).inc()
+
+    # ------------------------------------------------------------------
+    # Proxy metrics helpers
+    def proxy_inflight_inc(self, method: str) -> None:
+        self._proxy_inflight.labels(router=self.router_name, method=method).inc()
+
+    def proxy_inflight_dec(self, method: str) -> None:
+        self._proxy_inflight.labels(router=self.router_name, method=method).dec()
+
+    def record_proxy_attempt(self, method: str, outcome: str, status_code: str, duration: float) -> None:
+        labels = dict(router=self.router_name, method=method, outcome=outcome)
+        self._proxy_requests.labels(status_code=status_code, **labels).inc()
+        self._proxy_latency.labels(**labels).observe(duration)
+
+    def record_retry(self, reason: str) -> None:
+        self._proxy_retries.labels(router=self.router_name, reason=reason).inc()
+
+    def record_terminal_failure(self, reason: str) -> None:
+        self._proxy_failures.labels(router=self.router_name, reason=reason).inc()
+
+    # ------------------------------------------------------------------
+    # Health probe metrics helpers
+    def record_health_probe(self, worker: str, result: str, duration: float, success_timestamp: Optional[float] = None) -> None:
+        labels = dict(router=self.router_name, worker=worker)
+        self._health_probes.labels(result=result, **labels).inc()
+        self._health_latency.labels(**labels).observe(duration)
+        if result == "success" and success_timestamp is not None:
+            self._health_last_success.labels(**labels).set(success_timestamp)
+
+    # ------------------------------------------------------------------
+    def start_http_server(self, host: str, port: int) -> bool:
+        """Start the dedicated metrics HTTP server if not already running."""
+        with self._http_server_lock:
+            if self._http_server_port is not None:
+                return True
+            try:
+                start_http_server(port, addr=host, registry=self.registry)
+                self._http_server_port = port
+                logger.info(f"Router Prometheus metrics server listening on {host}:{port}")
+                return True
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.error(f"Failed to start router metrics server on {host}:{port}: {exc}")
+                return False


### PR DESCRIPTION
- Introduced Prometheus metrics instrumentation in the standalone router service.
- Added options for exposing metrics and configuring router name in the router command.
- Implemented metrics tracking for worker states, proxy requests, and health probes.
- Updated router runtime to initialize and manage metrics collection.
- Added unit tests to verify metrics functionality without a running server.