### PR TITLE
feat: Add pre-commands support to SLURM configuration and script ration

### DIFF
--- a/src/sgorch/config.py
+++ b/src/sgorch/config.py
@@ -96,6 +96,7 @@ class SlurmConfig(BaseModel):
     log_dir: str
     env: dict[str, str] = {}
     sbatch_extra: list[str] = []
+    pre_commands: list[str] = []
 
 
 class BackendBase(BaseModel):

--- a/src/sgorch/examples/config.yaml
+++ b/src/sgorch/examples/config.yaml
@@ -76,6 +76,11 @@ deployments:
         HF_HOME: "/cluster/home/jonalsa/.cache/huggingface"
         HUGGINGFACE_HUB_CACHE: "/cluster/home/jonalsa/.cache/huggingface"
       sbatch_extra: []        # free-form extras
+      pre_commands:           # commands to run before the main backend command
+        - "echo 'Setting up custom environment'"
+        - "module load cuda/12.1"
+        - "export CUSTOM_VAR=value"
+        - "mkdir -p /tmp/my-cache"
 
     health:
       path: "/health"

--- a/src/sgorch/reconciler.py
+++ b/src/sgorch/reconciler.py
@@ -428,7 +428,8 @@ class Reconciler:
             env_vars=self.config.slurm.env,
             remote_port=remote_port,
             health_path=self.config.health.path,
-            sbatch_extra=self.config.slurm.sbatch_extra
+            sbatch_extra=self.config.slurm.sbatch_extra,
+            pre_commands=self.config.slurm.pre_commands
         )
         
         return SubmitSpec(

--- a/src/sgorch/slurm/sbatch_templates.py
+++ b/src/sgorch/slurm/sbatch_templates.py
@@ -27,6 +27,7 @@ def render_sbatch_script(
     health_path: str = "/health",
     health_token_env: str = "WORKER_HEALTH_TOKEN",
     sbatch_extra: Optional[list[str]] = None,
+    pre_commands: Optional[list[str]] = None,
 ) -> str:
     """Render SLURM sbatch script template."""
 
@@ -94,8 +95,20 @@ def render_sbatch_script(
 
     script_lines.extend(launch_plan.setup_lines)
 
+    # Add user-defined pre-commands
+    if pre_commands:
+        script_lines.extend([
+            "",
+            "# User-defined pre-commands",
+        ])
+        for cmd in pre_commands:
+            script_lines.extend([
+                f"echo '[$(date \'+%Y-%m-%d %H:%M:%S\')] Running pre-command: {cmd}'",
+                cmd,
+            ])
+        script_lines.append("")
+
     script_lines.extend([
-        "",
         "# Get node hostname and IP",
         'HOSTNAME=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)',
         'IP=$(getent hosts "$HOSTNAME" | awk \'{print $1}\' | head -n1)',


### PR DESCRIPTION
- Introduced a new `pre_commands` field in the `SlurmConfig` class to allow user-defined commands before the main backend command.
- Updated the `render_sbatch_script` function to include the execution of pre-commands in the generated SLURM script.
- Modified example configuration to demonstrate the usage of pre-commands for environment setup.