### PR TITLE
feat: Enhance router metrics to include worker information

### DIFF
--- a/src/sgorch/router/metrics.py
+++ b/src/sgorch/router/metrics.py
@@ -42,13 +42,13 @@ class RouterMetrics:
         self._proxy_requests = Counter(
             "sgorch_router_proxy_requests_total",
             "Total proxy attempts to upstream workers",
-            ["router", "method", "outcome", "status_code"],
+            ["router", "method", "outcome", "status_code", "worker"],
             registry=self.registry,
         )
         self._proxy_latency = Histogram(
             "sgorch_router_proxy_request_latency_seconds",
             "Latency of proxy attempts to upstream workers",
-            ["router", "method", "outcome"],
+            ["router", "method", "outcome", "worker"],
             registry=self.registry,
         )
         self._proxy_inflight = Gauge(
@@ -114,8 +114,8 @@ class RouterMetrics:
     def proxy_inflight_dec(self, method: str) -> None:
         self._proxy_inflight.labels(router=self.router_name, method=method).dec()
 
-    def record_proxy_attempt(self, method: str, outcome: str, status_code: str, duration: float) -> None:
-        labels = dict(router=self.router_name, method=method, outcome=outcome)
+    def record_proxy_attempt(self, method: str, outcome: str, status_code: str, duration: float, worker: str) -> None:
+        labels = dict(router=self.router_name, method=method, outcome=outcome, worker=worker)
         self._proxy_requests.labels(status_code=status_code, **labels).inc()
         self._proxy_latency.labels(**labels).observe(duration)
 

--- a/src/sgorch/router/runtime.py
+++ b/src/sgorch/router/runtime.py
@@ -256,13 +256,13 @@ class RouterRuntime:
             )
         except httpx.RequestError as exc:
             if metrics and start is not None:
-                metrics.record_proxy_attempt(method, "error", "exception", perf_counter() - start)
+                metrics.record_proxy_attempt(method, "error", "exception", perf_counter() - start, worker_url)
             raise ProxyError(str(exc)) from exc
         else:
             if metrics and start is not None:
                 status_code = str(resp.status_code)
                 outcome = "success" if resp.status_code < 500 else "error"
-                metrics.record_proxy_attempt(method, outcome, status_code, perf_counter() - start)
+                metrics.record_proxy_attempt(method, outcome, status_code, perf_counter() - start, worker_url)
         finally:
             if metrics:
                 metrics.proxy_inflight_dec(method)


### PR DESCRIPTION
- Updated the RouterMetrics class to include a 'worker' label in proxy request and latency metrics.
- Modified the record_proxy_attempt method to accept a 'worker' parameter for better tracking of proxy attempts per worker.
- Adjusted the RouterRuntime class to pass the worker URL when recording proxy attempts, improving metrics granularity.